### PR TITLE
source a setenv file when entering a bookmarked directory for the first time

### DIFF
--- a/zshmarks.plugin.zsh
+++ b/zshmarks.plugin.zsh
@@ -31,17 +31,17 @@ function bookmark() {
 }
 
 source_setenv() {
-	bookmark=$1
+	bookmark_name=$1
 	# is there a setenv file to source
 	if [[ -f "setenv-source-me.sh" ]]; then
 
 		# if we have not already sourced it in the current zsh session ..
-		setenv_var="setenv_${bookmark}"
+		setenv_var=`echo "setenv_${bookmark_name}" | sed "s/[^a-zA-Z0-9]/_/g"`
 		if [[ -z ${(P)setenv_var} ]]; then
+			echo "sourceing 'setenv-source-me.sh'"
 			source setenv-source-me.sh
 			# remember that we have sourced it
 			eval "$setenv_var=sourced"
-			echo "sourced setenv-source-me.sh: $setenv_var"
 		fi
 	fi
 }


### PR DESCRIPTION
In some directories I need to set up some environment variables before I can go on.
I therefore write simple scripts (called setenv.sh or setenv-source-me.sh) that set up
the correct environment for the current project.

Now when a bookmarked directory is visited (jumped to) for the first time in the current session, and if there is a file `setenv-source-me.sh` then this file will be sourced
