### PR TITLE
Use and parse HOME environment variable

### DIFF
--- a/zshmarks.plugin.zsh
+++ b/zshmarks.plugin.zsh
@@ -19,7 +19,15 @@ function bookmark() {
 		echo '  bookmark foo'
 		return 1
 	else
-		bookmark="$(pwd)|$bookmark_name" # Store the bookmark as folder|name
+                
+                cur_dir="$(pwd)"
+
+                # Replace /home/uname with $HOME
+                if [[ "$cur_dir" =~ ^"$HOME"(/|$) ]]; then
+                        cur_dir="\$HOME${cur_dir#$HOME}"
+                fi
+
+		bookmark="$cur_dir|$bookmark_name" # Store the bookmark as folder|name
 		if [[ -z $(grep "$bookmark" $bookmarks_file) ]]; then
 			echo $bookmark >> $bookmarks_file
 			echo "Bookmark '$bookmark_name' saved"
@@ -58,7 +66,7 @@ function jump() {
 		return 1
 	else
 		dir="${bookmark%%|*}"
-		cd "${dir}"
+		eval "cd ${dir}"
 		source_setenv $bookmark_name
 		unset dir
 	fi


### PR DESCRIPTION
This commit changes the way bookmarks are stored if and only if they are subdirectories of your home directory. It replaces `/home/uname` with `$HOME`, and uses `eval "cd ${dir}" instead of just`cd "${dir}" so that the `$HOME` environment variable is parsed into `/home/uname` when you run `jump bookmark`.

The idea is that you should be able to have bookmarks referring to the same general locations in your home directory, which are valid across multiple machines that may have different usernames and home locations, so long as they have the same subdirectory structure.

This is particularly useful if you keep your dotfiles like your `.bookmark` file in a git repo, so that all you need to do is `git clone` it and even if it's a different machine/operating system (Linux or Mac OS), the bookmark files will work just fine (provided you retain the same subdirectory structure).
