### PR TITLE
Using local variable instead of unset

### DIFF
--- a/zshmarks.plugin.zsh
+++ b/zshmarks.plugin.zsh
@@ -87,9 +87,8 @@ function jump() {
 		echo "  bookmark foo"
 		return 1
 	else
-		dir="${bookmark%%|*}"
+		local dir="${bookmark%%|*}"
 		eval "cd \"${dir}\""
-		unset dir
 	fi
 }
 


### PR DESCRIPTION
This fixes the error

    jump:11: bad math expression: operand expected at `/home/phoe...'