### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ oh-my-zsh
 
         source ~/.zshrc
 
+Fig
+-------
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zshmarks` in just one click.
+
+<a href="https://fig.io/plugins/other/zshmarks_jocelynmallon" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 antigen
 -------
 Add `antigen bundle jocelynmallon/zshmarks` to your .zshrc where you're adding your other plugins. Antigen will clone the plugin for you and add it to your antigen setup the next time you start a new shell.


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Zshmarks is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!